### PR TITLE
Use argparse for arguments and add option to list pull requests for gardening

### DIFF
--- a/issue-stats.py
+++ b/issue-stats.py
@@ -6,8 +6,6 @@ from __future__ import print_function
 
 import sys, json, urllib2
 
-
-
 secrets = json.load(open("secrets.json"))
 client_id = secrets["client_id"]
 client_secret = secrets["client_secret"]
@@ -17,180 +15,197 @@ all_labels_file = "all-labels.json"
 
 
 def load_json(url):
-  response = urllib2.urlopen(url).read()
-  return json.loads(response)
+    response = urllib2.urlopen(url).read()
+    return json.loads(response)
+
 
 def get_next_url(response):
-  if "Link" not in response:
+    if "Link" not in response:
+        return None
+    link_header = response["Link"]
+    links = link_header.split(",")
+    for link_segment in links:
+        if link_segment.find("rel=\"next\"") == -1:
+            continue
+        link = link_segment[link_segment.index('<') +
+                            1:link_segment.index('>')]
+        return link
     return None
-  link_header = response["Link"]
-  links = link_header.split(",")
-  for link_segment in links:
-    if link_segment.find("rel=\"next\"") == -1:
-      continue
-    link = link_segment[link_segment.index('<')+1:link_segment.index('>')]
-    return link
-  return None
+
 
 def fetch_issues(query):
-  start_at = 0
-  url = 'https://api.github.com/repos/bazelbuild/bazel/issues?client_id=' + client_id + '&client_secret=' + client_secret + '&per_page=100&' + query;
-  result = dict()
-  while url != None:
-    print(url)
-    response = urllib2.urlopen(url)
-    issues = json.loads(response.read())
-    for issue in issues:
-      result[issue["number"]] = issue
-    url = get_next_url(response.info())
-  print(len(result))
-  return result.values()
+    start_at = 0
+    url = 'https://api.github.com/repos/bazelbuild/bazel/issues?client_id=' + client_id + '&client_secret=' + client_secret + '&per_page=100&' + query
+    result = dict()
+    while url != None:
+        print(url)
+        response = urllib2.urlopen(url)
+        issues = json.loads(response.read())
+        for issue in issues:
+            result[issue["number"]] = issue
+        url = get_next_url(response.info())
+    print(len(result))
+    return result.values()
 
 
 def dump_all_open_issues():
-  issues = fetch_issues("q=is:issue&is:open")
-  json.dump(issues, open(all_open_issues_file, "w+"), indent = 2)
+    issues = fetch_issues("q=is:issue&is:open")
+    json.dump(issues, open(all_open_issues_file, "w+"), indent=2)
 
 
 def dump_labels():
-  labels = []
-  url = 'https://api.github.com/repos/bazelbuild/bazel/labels?client_id=' + client_id + '&client_secret=' + client_secret
-  while url:
-    print(url)
-    response = urllib2.urlopen(url)
-    ls = json.loads(response.read())
-    labels += ls
-    url = get_next_url(response.info())
-  json.dump(labels, open(all_labels_file, "w+"), indent = 2)
+    labels = []
+    url = 'https://api.github.com/repos/bazelbuild/bazel/labels?client_id=' + client_id + '&client_secret=' + client_secret
+    while url:
+        print(url)
+        response = urllib2.urlopen(url)
+        ls = json.loads(response.read())
+        labels += ls
+        url = get_next_url(response.info())
+    json.dump(labels, open(all_labels_file, "w+"), indent=2)
+
 
 def update():
-  dump_all_open_issues()
-  dump_labels()
+    dump_all_open_issues()
+    dump_labels()
+
 
 #
 # Helpers
 #
-
 def issue_url(issue):
-  return "https://github.com/bazelbuild/bazel/issues/" + str(issue["number"])
+    return "https://github.com/bazelbuild/bazel/issues/" + str(issue["number"])
+
 
 def team_labels(labels):
-  for l in labels:
-    if l["name"].startswith("team-"):
-      yield l
+    for l in labels:
+        if l["name"].startswith("team-"):
+            yield l
+
 
 def all_teams(labels):
-  teams = []
-  for team_label in team_labels(labels):
-    yield team_label["name"]
+    teams = []
+    for team_label in team_labels(labels):
+        yield team_label["name"]
 
 
 #
 # Issue predicates
 #
 def has_team_label(issue):
-  for _ in team_labels(issue["labels"]):
-    return True
-  return False
+    for _ in team_labels(issue["labels"]):
+        return True
+    return False
+
 
 def is_pull_request(issue):
-  return "pull_request" in issue
+    return "pull_request" in issue
+
 
 def has_label(issue, label):
-  for l in issue["labels"]:
-    if l["name"] == label:
-      return True
-  return False
+    for l in issue["labels"]:
+        if l["name"] == label:
+            return True
+    return False
 
 
 def has_any_of_labels(issue, labels):
-  for l in issue["labels"]:
-    if l["name"] in labels:
-      return True
-  return False
+    for l in issue["labels"]:
+        if l["name"] in labels:
+            return True
+    return False
+
 
 def has_priority(issue):
-  return has_any_of_labels(issue, ["P0", "P1", "P2", "P3"])
+    return has_any_of_labels(issue, ["P0", "P1", "P2", "P3"])
+
 
 def teams(issue):
-  return map(lambda i:i["name"], team_labels(issue["labels"]))
+    return map(lambda i: i["name"], team_labels(issue["labels"]))
 
 
 #
 # Reports
 #
 
-def print_report(issues,
-           header,
-           predicate,
-           printer):
-  print(header)
-  count = 0
-  for issue in issues:
-    if predicate(issue):
-      count = count + 1
-      print(printer(issue))
-  print("%d issues" % count)
-  print("---------------------------")
+
+def print_report(issues, header, predicate, printer):
+    print(header)
+    count = 0
+    for issue in issues:
+        if predicate(issue):
+            count = count + 1
+            print(printer(issue))
+    print("%d issues" % count)
+    print("---------------------------")
 
 
 def issues_without_team(issues):
-  print_report(issues,
-    header ="Open issues not assigned to any team",
-    predicate = lambda(issue): not has_team_label(issue),
-    printer = lambda(issue): "%s: %s" % (issue["number"],issue_url(issue)),
-  )
+    print_report(
+        issues,
+        header="Open issues not assigned to any team",
+        predicate=lambda (issue): not has_team_label(issue),
+        printer=lambda (issue): "%s: %s" % (issue["number"], issue_url(issue)),
+    )
 
 
 def more_than_one_team(issues):
-  def predicate(issue):
-    return len(teams(issue)) > 1
-  def printer(issue):
-    n = issue["number"]
-    return "%s: %s %s" % (n, ",".join(teams(issue)), issue_url(issue))
-  print_report(issues,
-               header = "Issues assigned to more than one team:",
-               predicate = predicate,
-               printer = printer)
+    def predicate(issue):
+        return len(teams(issue)) > 1
+
+    def printer(issue):
+        n = issue["number"]
+        return "%s: %s %s" % (n, ",".join(teams(issue)), issue_url(issue))
+
+    print_report(
+        issues,
+        header="Issues assigned to more than one team:",
+        predicate=predicate,
+        printer=printer)
+
 
 def have_team_no_untriaged_no_priority(issues):
-  print_report(issues,
-    header = "Triaged issues without priority",
-               predicate = lambda(issue): has_team_label(issue) and not has_label(issue, "untriaged") and not has_priority(issue),
-               printer = lambda(issue): "%s: %s (%s)" % (issue["number"], issue_url(issue), ",".join(teams(issue)))
-  )
+    print_report(issues,
+      header = "Triaged issues without priority",
+                 predicate = lambda(issue): has_team_label(issue) and not has_label(issue, "untriaged") and not has_priority(issue),
+                 printer = lambda(issue): "%s: %s (%s)" % (issue["number"], issue_url(issue), ",".join(teams(issue)))
+    )
 
 
 def issues_to_garden(issues):
-  print_report(issues,
-      header = "Open issues not assigned to any team or person",
-      predicate = lambda(issue): not has_team_label(issue) and not issue["assignee"] and not is_pull_request(issue),
-      printer = lambda(issue): "%s: %s" % (issue["number"],issue_url(issue))
-  )
+    print_report(
+        issues,
+        header="Open issues not assigned to any team or person",
+        predicate=
+        lambda (issue): not has_team_label(issue) and not issue["assignee"] and not is_pull_request(issue),
+        printer=lambda (issue): "%s: %s" % (issue["number"], issue_url(issue)))
 
 
 def report():
-  issues = json.load(open(all_open_issues_file))
-  more_than_one_team(issues)
-  issues_without_team(issues)
-  have_team_no_untriaged_no_priority(issues)
+    issues = json.load(open(all_open_issues_file))
+    more_than_one_team(issues)
+    issues_without_team(issues)
+    have_team_no_untriaged_no_priority(issues)
+
 
 def garden():
-  issues = json.load(open(all_open_issues_file))
-  issues_to_garden(issues)
+    issues = json.load(open(all_open_issues_file))
+    issues_to_garden(issues)
+
 
 def main():
-  if len(sys.argv) != 2:
-    print("Usage: %s (update|report|garden)" % sys.argv[0])
-    exit(1)
-  if sys.argv[1] == "update":
-    update()
-  elif sys.argv[1] == "report":
-    report()
-  elif sys.argv[1] == "garden":
-    garden()
-  else:
-    print("Usage: %s (update|report|garden)" % sys.argv[0])
-    exit(1)
+    if len(sys.argv) != 2:
+        print("Usage: %s (update|report|garden)" % sys.argv[0])
+        exit(1)
+    if sys.argv[1] == "update":
+        update()
+    elif sys.argv[1] == "report":
+        report()
+    elif sys.argv[1] == "garden":
+        garden()
+    else:
+        print("Usage: %s (update|report|garden)" % sys.argv[0])
+        exit(1)
+
 
 main()

--- a/issue-stats.py
+++ b/issue-stats.py
@@ -218,15 +218,15 @@ def main():
     garden_parser = subparsers.add_parser("garden", help="generate issues/pull requests that need gardening attention")
     garden_parser.add_argument(
         '-i',
-        '--issues',
-        action='store_true',
+        '--list_issues',
         default=True,
+        type=lambda x: (str(x).lower() == 'true'),
         help="list issues that need attention")
     garden_parser.add_argument(
         '-p',
-        '--pull_requests',
-        action='store_true',
+        '--list_pull_requests',
         default=True,
+        type=lambda x: (str(x).lower() == 'true'),
         help="list pull requests that need attention")
     args = parser.parse_args()
 
@@ -235,7 +235,7 @@ def main():
     elif args.command == "report":
         report()
     elif args.command == "garden":
-        garden(args.issues, args.pull_requests)
+        garden(args.list_issues, args.list_pull_requests)
 
 
 main()

--- a/issue-stats.py
+++ b/issue-stats.py
@@ -221,13 +221,13 @@ def main():
         '--list_issues',
         default=True,
         type=lambda x: (str(x).lower() == 'true'),
-        help="list issues that need attention")
+        help="list issues that need attention (true/false)")
     garden_parser.add_argument(
         '-p',
         '--list_pull_requests',
         default=True,
         type=lambda x: (str(x).lower() == 'true'),
-        help="list pull requests that need attention")
+        help="list pull requests that need attention (true/false)")
     args = parser.parse_args()
 
     if args.command == "update":


### PR DESCRIPTION
This PR builds on #2. 

```
$ ./issue-stats.py
usage: issue-stats.py [-h] {update,report,garden} ...
issue-stats.py: error: too few arguments

$ ./issue-stats.py -h
usage: issue-stats.py [-h] {update,report,garden} ...

Gather Bazel's issues and pull requests data

positional arguments:
  {update,report,garden}
                        select a command
    update              update the datasets
    report              generate a full report
    garden              generate issues/pull requests that need gardening
                        attention

optional arguments:
  -h, --help            show this help message and exit

$ ./issue-stats.py garden -h
usage: issue-stats.py garden [-h] [-i LIST_ISSUES] [-p LIST_PULL_REQUESTS]

optional arguments:
  -h, --help            show this help message and exit
  -i LIST_ISSUES, --list_issues LIST_ISSUES
                        list issues that need attention (true/false)
  -p LIST_PULL_REQUESTS, --list_pull_requests LIST_PULL_REQUESTS
                        list pull requests that need attention (true/false)
```

The default is to show both gardenable issues and prs.