### PR TITLE
Default to incremental issue update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,3 @@ Usage:
    `issue-stats.py garden`
 1. Feel free to modify those - I hope code is self-explanatory.
 
-

--- a/issue-stats.py
+++ b/issue-stats.py
@@ -5,7 +5,9 @@ import argparse
 import itertools
 import json
 import urllib.request
+import ssl
 
+ssl._create_default_https_context = ssl._create_unverified_context
 secrets = json.load(open("secrets.json"))
 client_id = secrets["client_id"]
 client_secret = secrets["client_secret"]

--- a/issue-stats.py
+++ b/issue-stats.py
@@ -53,7 +53,7 @@ def get_next_url(response):
     return None
 
 
-def fetch_issues(repo, query, modified_after=None):
+def fetch_issues(repo, query, type='issues', modified_after=None):
     """Fetches issues from a repo.
 
     Args:
@@ -69,11 +69,12 @@ def fetch_issues(repo, query, modified_after=None):
     if modified_after:
         query_args.append('since=%s' % datetime.datetime.utcfromtimestamp(
             modified_after).strftime('%Y-%m-%dT%H:%M:%SZ'))
-    url = GITHUB_API_URL_BASE + repo + '/issues?' + '&'.join(query_args)
+    url = GITHUB_API_URL_BASE + repo + '/' + type + '?' + '&'.join(query_args)
     result = dict()
     i = 0
     while url:
         print(url)
+        print(add_client_secret(url))
         response = urllib.request.urlopen(add_client_secret(url))
         issues = json.loads(response.read())
         for issue in issues:
@@ -106,18 +107,21 @@ def update(full_update=False):
         db_time = None
         issues = []
     else:
-        # Notice the hackery. We ask for 10 minutes before the mod time so we
-        # pick up issues that were modified *during* the last time we queried.
-        # We could do better by finding the highest mod time in the database.
-        db_time = os.path.getmtime(all_issues_file) - 600
         with open(all_issues_file) as issues_db:
             issues = json.load(issues_db)
         url_to_issue = {}
+        latest_change = None
         for issue_index in range(len(issues)):
             issue  = issues[issue_index]
             url_to_issue[issue_url(issue)] = issue_index
+            dt = parse_datetime(issue["updated_at"])
+            if latest_change == None or latest_change < dt:
+                latest_change = dt
+        db_time = latest_change.timestamp() - 60 * 60 * 24 * 5
+
     for repo in REPOS:
-        new_issues = fetch_issues(repo, "", modified_after=db_time)
+      for type in ['issues', 'pulls']:
+        new_issues = fetch_issues(repo, "", type=type, modified_after=db_time)
         if full_update:
             issues.extend(new_issues)
         else:

--- a/issue-stats.py
+++ b/issue-stats.py
@@ -4,6 +4,7 @@ import datetime
 import argparse
 import itertools
 import json
+import os
 import urllib.request
 import ssl
 
@@ -52,14 +53,23 @@ def get_next_url(response):
     return None
 
 
-def fetch_issues(repo, query):
+def fetch_issues(repo, query, modified_after=None):
     """Fetches issues from a repo.
 
     Args:
       repo: (str) '<organization>/<repo>'
       query: (str) optional query
+      modified_after: (float) only fetch issues modified after this (UTC) time.
     """
-    url = GITHUB_API_URL_BASE + repo + '/issues?per_page=100&' + query
+    query_args = [
+        'per_page=100',
+    ]
+    if query:
+        query_args.append(query)
+    if modified_after:
+        query_args.append('since=%s' % datetime.datetime.utcfromtimestamp(
+            modified_after).strftime('%Y-%m-%dT%H:%M:%SZ'))
+    url = GITHUB_API_URL_BASE + repo + '/issues?' + '&'.join(query_args)
     result = dict()
     i = 0
     while url:
@@ -71,13 +81,6 @@ def fetch_issues(repo, query):
         url = get_next_url(response.info())
     print(len(result))
     return list(result.values())
-
-
-def dump_issues():
-    issues = []
-    for repo in REPOS:
-        issues.extend(fetch_issues(repo, ""))
-    json.dump(issues, open(all_issues_file, "w+"), indent=2)
 
 
 def label_file_for_repo(repo):
@@ -98,10 +101,38 @@ def dump_labels(repo):
     json.dump(labels, open(label_file_for_repo(repo), "w+"), indent=2)
 
 
-def update():
-    dump_issues()
+def update(full_update=False):
+    if full_update:
+        db_time = None
+        issues = []
+    else:
+        # Notice the hackery. We ask for 10 minutes before the mod time so we
+        # pick up issues that were modified *during* the last time we queried.
+        # We could do better by finding the highest mod time in the database.
+        db_time = os.path.getmtime(all_issues_file) - 600
+        with open(all_issues_file) as issues_db:
+            issues = json.load(issues_db)
+        url_to_issue = {}
+        for issue_index in range(len(issues)):
+            issue  = issues[issue_index]
+            url_to_issue[issue_url(issue)] = issue_index
     for repo in REPOS:
-      dump_labels(repo)
+        new_issues = fetch_issues(repo, "", modified_after=db_time)
+        if full_update:
+            issues.extend(new_issues)
+        else:
+            for issue in new_issues:
+                url = issue_url(issue)
+                if url in url_to_issue:
+                    print("updating %s" % url)
+                    issues[url_to_issue.get(url)] = issue
+                else:
+                    print("new issue %s" % url)
+                    issues.append(issue)
+    json.dump(issues, open(all_issues_file, "w+"), indent=2)
+    for repo in REPOS:
+        dump_labels(repo)
+
 
 
 #
@@ -344,7 +375,10 @@ def main():
         description="Gather Bazel's issues and pull requests data")
     subparsers = parser.add_subparsers(dest="command", help="select a command")
 
-    subparsers.add_parser("update", help="update the datasets")
+    update_parser = subparsers.add_parser("update", help="update the datasets")
+    update_parser.add_argument(
+        "--full", action='store_true',
+        help="Do a full rather than incremental update")
 
     report_parser = subparsers.add_parser(
         "report", help="generate a full report")
@@ -387,7 +421,7 @@ def main():
     args = parser.parse_args()
 
     if args.command == "update":
-        update()
+        update(args.full)
     elif args.command == "report":
         report(args.report if args.report else list(reports.keys()))
     elif args.command == "garden":

--- a/issue-stats.py
+++ b/issue-stats.py
@@ -115,7 +115,7 @@ def parse_datetime(datetime_string):
 
 
 def issue_url(issue):
-    return issue["url"]
+    return issue["html_url"]
 
 
 def team_labels(labels):


### PR DESCRIPTION
Instead of getting the entire set of issues, only download the ones since the last database modification.

The time on that is a little hacky. The better idea would be to find the greatest mod time of all the issues in the database. I will do that in another pass.