### PR TITLE
Add stale PR report for open pull requests that haven't been addressed in 14 days

### DIFF
--- a/reports.py
+++ b/reports.py
@@ -29,6 +29,7 @@ CAT_2_TEAM = {
 #
 
 # Look for WIP markers in issue titles
+_WIP_RE = re.compile(r'\bwip:?\b')
 
 # GitHub API datetime-stamps are already in UTC / Zulu time (+0000)
 def parse_datetime(datetime_string):
@@ -101,8 +102,8 @@ def needs_more_data(issue):
 
 
 def work_in_progress(issue):
-    return has_label(issue, "WIP") or \
-         re.compile(r'\bwip:?\b').search(issue["title"].lower())
+    return has_label(issue, "WIP") or _WIP_RE.search(issue["title"].lower())
+
 
 
 def teams(issue):
@@ -243,11 +244,12 @@ def have_team_no_untriaged_no_priority(reporter, issues):
 
 def stale_pull_requests(reporter, issues, days):
     def predicate(issue):
-        return \
-            is_open(issue) \
-            and is_pull_request(issue) \
-            and is_stale(issue, days) \
+        return (
+            is_open(issue)
+            and is_pull_request(issue)
+            and is_stale(issue, days)
             and not work_in_progress(issue)
+        )
 
     reporter(
         issues,

--- a/reports.py
+++ b/reports.py
@@ -31,6 +31,7 @@ CAT_2_TEAM = {
 # Look for WIP markers in issue titles
 _WIP_RE = re.compile(r'\bwip:?\b')
 
+
 # GitHub API datetime-stamps are already in UTC / Zulu time (+0000)
 def parse_datetime(datetime_string):
     return datetime.datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%SZ")

--- a/reports.py
+++ b/reports.py
@@ -105,7 +105,6 @@ def work_in_progress(issue):
     return has_label(issue, "WIP") or _WIP_RE.search(issue["title"].lower())
 
 
-
 def teams(issue):
     return map(lambda i: i["name"], team_labels(issue["labels"]))
 


### PR DESCRIPTION
```
$ ./issue-stats.py report -r stale_pull_requests_14d | grep bazelbuild/bazel/ | sort -n
17   | 7579 | https://github.com/bazelbuild/bazel/pull/7579   | Moved `static_link_msvcrt` to Starlark.           
18   | 8684 | https://github.com/bazelbuild/bazel/pull/8684   | Added HttpContentDecompressor to HttpBlobStore d..
18   | 8768 | https://github.com/bazelbuild/bazel/pull/8768   | DO NOT SUBMIT: Windows Sandbox                    
20   | 6919 | https://github.com/bazelbuild/bazel/pull/6919   | Preprocess .asm files                             
24   | 8167 | https://github.com/bazelbuild/bazel/pull/8167   | [Cpp] Allow .so files to have more extensions.    
25   | 7862 | https://github.com/bazelbuild/bazel/pull/7862   | Fix aquery crash for bitcode feature              
28   | 8047 | https://github.com/bazelbuild/bazel/pull/8047   | correctly access javabase in java_integration_te..
28   | 8680 | https://github.com/bazelbuild/bazel/pull/8680   | Allow passing extra HTTP headers to remote cache  
30   | 8701 | https://github.com/bazelbuild/bazel/pull/8701   | Cap Android persistent workers' max instances at..
32   | 8613 | https://github.com/bazelbuild/bazel/pull/8613   | Embed a default java_toolchain macro into java_t..
32   | 8620 | https://github.com/bazelbuild/bazel/pull/8620   | Remove tools/jdk/default_java_toolchain.bzl.      
35   | 8514 | https://github.com/bazelbuild/bazel/pull/8514   |  Flip `--incompatible_enable_cc_toolchain_resolu..
38   | 6857 | https://github.com/bazelbuild/bazel/pull/6857   | Send and receive work requests via proxy and mul..
38   | 8209 | https://github.com/bazelbuild/bazel/pull/8209   | Always report when a package is done to the Pack..
39   | 7756 | https://github.com/bazelbuild/bazel/pull/7756   | Clarify that BUILD files of non-Bazel projects s..
40   | 8533 | https://github.com/bazelbuild/bazel/pull/8533   | Upgrade to javac12.                               
41   | 4889 | https://github.com/bazelbuild/bazel/pull/4889   | Initial attempt at direct s3 remote cache         
41   | 8011 | https://github.com/bazelbuild/bazel/pull/8011   | Update grpc/build_defs.bzl to pass action tools ..
41   | 8046 | https://github.com/bazelbuild/bazel/pull/8046   | make bazel_sandboxing_cpp_test work with bazel-t..
41   | 8279 | https://github.com/bazelbuild/bazel/pull/8279   | Canonicalise install path for comparison          
44   | 8269 | https://github.com/bazelbuild/bazel/pull/8269   | Allow TreeArtifacts with any name in Starlark C+..
47   | 8322 | https://github.com/bazelbuild/bazel/pull/8322   | Pass stdin through test-setup.sh                  
47   | 8540 | https://github.com/bazelbuild/bazel/pull/8540   | Update implementation of fail()                   
54   | 5862 | https://github.com/bazelbuild/bazel/pull/5862   | [pkg_tar] Package py_binary runfiles correctly    
61   | 8094 | https://github.com/bazelbuild/bazel/pull/8094   | Update remote-caching.md                          
65   | 7380 | https://github.com/bazelbuild/bazel/pull/7380   | Always print the gRPC status code when it's not ..
69   | 8265 | https://github.com/bazelbuild/bazel/pull/8265   | Add repo rule for fetching a Python SDK           
81   | 7978 | https://github.com/bazelbuild/bazel/pull/7978   | http_archive rule now has an ability to authenti..
82   | 8107 | https://github.com/bazelbuild/bazel/pull/8107   | Starlark API to allow rules and genrules to decl..
83   | 7846 | https://github.com/bazelbuild/bazel/pull/7846   | Progressively retrying uploads to bytestream      
88   | 6620 | https://github.com/bazelbuild/bazel/pull/6620   | Remove confusing alias / config_setting document..
89   | 7042 | https://github.com/bazelbuild/bazel/pull/7042   | Java stub: add native library dirs to both java...
95   | 7624 | https://github.com/bazelbuild/bazel/pull/7624   | Add common envs attribute for *_binary and *_tes..
96   | 7424 | https://github.com/bazelbuild/bazel/pull/7424   | Git repo cache                                    
96   | 7680 | https://github.com/bazelbuild/bazel/pull/7680   | Predictable generation of import library on Wind..
97   | 7774 | https://github.com/bazelbuild/bazel/pull/7774   | Default runfiles to upwards directory as fallbac..
107  | 6532 | https://github.com/bazelbuild/bazel/pull/6532   | Give imported packages lower precedence than sta..
115  | 3671 | https://github.com/bazelbuild/bazel/pull/3671   | Add -v, --version flag                            
115  | 3855 | https://github.com/bazelbuild/bazel/pull/3855   | Integrate abseil-py to replace deprecated gflags..
122  | 7681 | https://github.com/bazelbuild/bazel/pull/7681   | Update protobuf to 3.7.1                          
138  | 7521 | https://github.com/bazelbuild/bazel/pull/7521   | Expose Go libraries for Build Event Streams.      
143  | 6981 | https://github.com/bazelbuild/bazel/pull/6981   | Use artifact id and sha1 for cache key type for ..
145  | 7536 | https://github.com/bazelbuild/bazel/pull/7536   | Configure Renovate                                
149  | 7329 | https://github.com/bazelbuild/bazel/pull/7329   | Explicitly specifies -target and -arch flags for..
152  | 6554 | https://github.com/bazelbuild/bazel/pull/6554   | Support collecting coverage for C-only targets    
152  | 6606 | https://github.com/bazelbuild/bazel/pull/6606   | Support DebugFission with `cc_configure`          
152  | 7363 | https://github.com/bazelbuild/bazel/pull/7363   | ci: Reverts to using += for setting the files va..
174  | 6657 | https://github.com/bazelbuild/bazel/pull/6657   | Describe known issue when in-mem state is lost w..
185  | 4855 | https://github.com/bazelbuild/bazel/pull/4855   | add skylint check for missing rule documentation  
185  | 5063 | https://github.com/bazelbuild/bazel/pull/5063   | Enhance documentation search experience (adding ..
185  | 5809 | https://github.com/bazelbuild/bazel/pull/5809   | Allow tool_path to be unnormalized.               
185  | 5996 | https://github.com/bazelbuild/bazel/pull/5996   | Issue #3709: Better Invalid SHA256 checksum mess..
185  | 6312 | https://github.com/bazelbuild/bazel/pull/6312   | scripts: make target for bash_completion with no..
185  | 6329 | https://github.com/bazelbuild/bazel/pull/6329   | Remove duplicate code in j2objc_dead_code_pruner  
185  | 6352 | https://github.com/bazelbuild/bazel/pull/6352   | Ensure that output files of targets passed to sh..
185  | 6632 | https://github.com/bazelbuild/bazel/pull/6632   | Enable custom py_binary stub_template attribute   
185  | 6810 | https://github.com/bazelbuild/bazel/pull/6810   | remote: add aws auth for remote caching           
```