### PR TITLE
Create new download records with a 0 count rather than -1.

### DIFF
--- a/create_tables.sql
+++ b/create_tables.sql
@@ -5,11 +5,11 @@
 CREATE TABLE IF NOT EXISTS gh_downloads(
   sample_date DATE,
   filename VARCHAR(200),
-  downloads INT DEFAULT -1,  # downloads today
+  downloads INT DEFAULT 0,  # downloads today
   downloads_total INT, # cumulative downloads of all time
-  sha256 INT DEFAULT -1,
+  sha256 INT DEFAULT 0,
   sha256_total INT,
-  sig INT DEFAULT -1,
+  sig INT DEFAULT 0,
   sig_total INT,
   product VARCHAR(50),
   version VARCHAR(50),

--- a/delta.py
+++ b/delta.py
@@ -75,7 +75,7 @@ def ComputeDailyDownloads(connection, trailing_days):
         if (last_day and last_filename == filename
             and last_version == version):
           u_downloads = u_sha256 = u_sig = -1
-          if downloads is None or downloads < 0:
+          if downloads is None or downloads <= 0:
             u_downloads = downloads_total - last_downloads
 
           # This corrects the 2019-04-15 problem. We had no data between 4/2
@@ -92,11 +92,11 @@ def ComputeDailyDownloads(connection, trailing_days):
             else:
               u_downloads = -1
 
-          if sha256 is None or sha256 < 0:
+          if sha256 is None or sha256 <= 0:
             u_sha256 = sha256_total - last_sha256
-          if sig is None or sig < 0:
+          if sig is None or sig <= 0:
             u_sig = sig_total - last_sig
-          if u_downloads >= 0 or u_sha256 >= 0 or u_sig >= 0:
+          if u_downloads > 0 or u_sha256 > 0 or u_sig > 0:
             updates.append((filename, version, sample_date, u_downloads, u_sha256, u_sig))
 
         last_filename = filename

--- a/upload.py
+++ b/upload.py
@@ -66,7 +66,7 @@ def upload_file(file, connection):
             downloads, sha256, sig)
         VALUES(
             '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%d',
-            -1, -1, -1
+            0, 0, 0
         )""" % (sample.ymd, sample.file,
                 sample.downloads, sample.downloads_sha, sample.downloads_sig,
                 sample.product, sample.version, sample.arch, sample.os,


### PR DESCRIPTION
This reduces the number of records needing daily count
backfill by over 50%, since many old versions do not get
any more downloads.