### PR TITLE
Add ability to specify specific repositories to scan on the command line

### DIFF
--- a/issue_stats.py
+++ b/issue_stats.py
@@ -41,8 +41,7 @@ def build_issue_index(issues, reset_repos):
     # for different repos in each run.
     repo_to_latest = {}
     url_to_issue = {}
-    for issue_index in range(len(issues)):
-        issue  = issues[issue_index]
+    for issue_index, issue in enumerate(issues):
         url_to_issue[issue['url']] = issue_index
         dt = database.update_time(issue)
         repo = '/'.join(issue['repository_url'].split('/')[-2:])
@@ -122,7 +121,7 @@ def main():
         help='Get repositories listed in this file')
     update_parser.add_argument(
         '--reset_repo', action='append',
-        help='Specific repository to do a full update for.')
+        help='Specific repository to do a full update for. May be repeated')
 
     garden_parser = subparsers.add_parser(
         "garden",

--- a/issue_stats_test.py
+++ b/issue_stats_test.py
@@ -9,6 +9,8 @@ import issue_stats
 class IssueStatsTest(unittest.TestCase):
 
   def setUp(self):
+    # This is just a frozen copy of a database sample as of 2019-08-23. If you
+    # update it by taking a new sample, You will have to adjust the counts.
     with open('testdata/issue_db.json', 'r') as issues_db:
       self.issues = json.load(issues_db)
 

--- a/issue_stats_test.py
+++ b/issue_stats_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Tests for issue-stats.py."""
+
+import json
+import unittest
+
+import issue_stats
+
+class IssueStatsTest(unittest.TestCase):
+
+  def setUp(self):
+    with open('testdata/issue_db.json', 'r') as issues_db:
+      self.issues = json.load(issues_db)
+
+  def test_build_issue_index(self):
+    url_to_issue, repo_to_latest = issue_stats.build_issue_index(
+        self.issues, [])
+
+    self.assertEqual(len(url_to_issue), 11609)
+    self.assertEqual(len(repo_to_latest), 32)
+    self.assertEqual(len([date for date in repo_to_latest.values() if date]),
+                     32)
+
+  def test_build_issue_index_with_reset(self):
+    url_to_issue, repo_to_latest = issue_stats.build_issue_index(
+        self.issues, ['bazelbuild/starlark', 'bazelbuild/buildtools'])
+
+    self.assertEqual(len(url_to_issue), 11609)
+    self.assertEqual(len(repo_to_latest), 32)
+    self.assertEqual(len([date for date in repo_to_latest.values() if date]),
+                     30)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Add ability to specify specific repositories to scan on the command line
Add ability to specify specific repositories to do a non-incremental
load for on the command line.

Together, this provides a way to reset individual repositories
that got stale data before we had incremental update correct.