### PR TITLE
add nodejs. make categorize work for nodejs

### DIFF
--- a/categorize.py
+++ b/categorize.py
@@ -11,16 +11,16 @@ Buckets = collections.namedtuple(
     'product version arch os packaging installer is_bin attributes leftover')
 
 # Capture well known version patterns
-_VERSION_RE = re.compile(''.join([
-    r'[-_.]'
-    r'v?',  # preceed by separator, with an optional 'v', which we strip
+_VERSION_RE = re.compile(
+    r'[-_.]'  # preceed by separator
+    r'v?'  # with an optional 'v', which we strip in code
     # classic m.n.p with optional '-alpha-N'
-    r'(\d+\.\d+\.\d+-((alpha)|(beta)|(gamma))[.-]?\d+)',
-    r'|(\d+\.\d+\.\d+(-?rc\d+)?)', # m.n.p-RCN
-    r'|(\d+\.\d+\.\d+[abcdefg]?)',
-    r'|(\d+\.\d+[abcdefg])',
-    r'|(\d+\.\d+(-?rc\d+)?)',    # m.n-rcN
-    ]))
+    r'(\d+\.\d+\.\d+-((alpha)|(beta)|(gamma))[.-]?\d+)'
+    r'|(\d+\.\d+\.\d+(-?rc\d+)?)'  # m.n.p-RCN
+    r'|(\d+\.\d+\.\d+[abcdefg]?)'
+    r'|(\d+\.\d+[abcdefg])'  # 1.0a
+    r'|(\d+\.\d+(-?rc\d+)?)'  # m.n-rcN
+    )
 
 _PRODUCT_VERSION_RE = re.compile(r'(\w+[-\w]*)[-_.]v?(\d+\.\d+\.\d+[a-z\d]*)[^.\D]?')
 #  bazel-toolchains-0dc4917.tar.gz

--- a/categorize_test.py
+++ b/categorize_test.py
@@ -26,15 +26,17 @@ class CategorizeTest(unittest.TestCase):
           else:
             buckets = categorize.Categorize(file,
                                             default_version=version)
-          self.assertEqual(product, buckets.product)
-          self.assertEqual(version, buckets.version)
-          self.assertEqual(arch, str(buckets.arch))
-          self.assertEqual(os, str(buckets.os))
-          self.assertEqual(packaging, str(buckets.packaging))
-          self.assertEqual(installer, buckets.installer)
-          self.assertEqual(is_bin, str(buckets.is_bin))
-          self.assertEqual(rest, '{%s}%s' % (buckets.attributes,
-                                             buckets.leftover))
+          self.assertEqual(product, buckets.product, str(buckets))
+          self.assertEqual(version, buckets.version, str(buckets))
+          self.assertEqual(arch, str(buckets.arch), str(buckets))
+          self.assertEqual(os, str(buckets.os), str(buckets))
+          self.assertEqual(packaging, str(buckets.packaging), str(buckets))
+          self.assertEqual(installer, buckets.installer, str(buckets))
+          self.assertEqual(is_bin, str(buckets.is_bin), str(buckets))
+          self.assertEqual(
+              rest,
+              '{%s}%s' % (buckets.attributes, buckets.leftover),
+              str(buckets))
 
 
 if __name__ == '__main__':

--- a/repos_misc.txt
+++ b/repos_misc.txt
@@ -6,4 +6,5 @@ bazelbuild/intellij
 bazelbuild/rules_docker
 bazelbuild/rules_jvm_external
 bazelbuild/rules_k8s
+bazelbuild/rules_nodejs
 bazelbuild/rules_sass

--- a/testdata/categorize_samples.txt
+++ b/testdata/categorize_samples.txt
@@ -790,3 +790,12 @@ unused_deps.mac|unused_deps|0.25.0|None|None|mac|standalone|True|{}
 unused_deps.osx|unused_deps|0.11.1|None|macos|None|standalone|True|{}
 unused_deps|unused_deps|0.11.1|None|None|None|standalone|True|{}
 unused_deps|unused_deps|0.19.2.1|None|None|None|standalone|True|{}
+rules_nodejs-0.26.0-beta.0.tar.gz|rules_nodejs|0.26.0-beta.0|src|any|tar.gz|standalone|True|{}
+bazel-1.0.0-rc1-linux-x86_64|bazel|1.0.0-rc1|x86_64|linux|None|standalone|True|{}
+bazel-1.0.0rc2-linux-x86_64|bazel|1.0.0rc2|x86_64|linux|None|standalone|True|{}
+bazel-1.0-rc1-linux-x86_64|bazel|1.0-rc1|x86_64|linux|None|standalone|True|{}
+bazel-1.0rc2-linux-x86_64|bazel|1.0rc2|x86_64|linux|None|standalone|True|{}
+bazel-0.8.tar.gz|bazel|0.8|src|any|tar.gz|standalone|True|{}
+endsinv-0.8.tar.gz|endsinv|0.8|src|any|tar.gz|standalone|True|{}
+endsinv-0.8b.tar.gz|endsinv|0.8b|src|any|tar.gz|standalone|True|{}
+endsinv-0.8.0c.tar.gz|endsinv|0.8.0c|src|any|tar.gz|standalone|True|{}


### PR DESCRIPTION
I expanded the meta regex for version patterns and moved the check for it ahead of the test for "product-version".  

Added additional unit tests to cover the oddballs and rules_nodejs-0.26.0-beta.0.tar.gz
