### PR TITLE
Change date computations from days since epoch to days between dates

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -20,14 +20,17 @@ DownloadSample = collections.namedtuple(
     ' downloads downloads_total sha256 sha256_total sig sig_total')
 DownloadSample.__new__.__defaults__ = (None,) * 14
 
+_EPOCH = datetime.datetime.strptime('2019-01-01', '%Y-%m-%d')
+_VERBOSE = False
 
-def NoneToNull(s):
+
+def none_to_null(s):
   if s == 'None':
     return ''
   return s
 
 
-def GatherPreviousDownloads(connection, trailing_days):
+def gather_previous_downloads(connection, trailing_days):
   """Get trailing_days worth of download records.
 
   We work in a 'days from 2019-01-01' system, so that the 'day' of any sample
@@ -94,89 +97,152 @@ def GatherPreviousDownloads(connection, trailing_days):
   return ret
 
 
-def upload_file(file, history, connection, dry_run=True):
-  if not dry_run:
-    cursor = connection.cursor()
+class DailyCountUploader(object):
 
-  epoch = datetime.datetime.strptime('2019-01-01', '%Y-%m-%d')
-  with open(file, 'r') as inp:
-    print('uploading:', file)
-    for line in inp:
-      # file| ymd | hm | count | #sha | #sig | product | version | arch | os
-      #     extension
-      parts = line.strip().split('|')
-      sample = DownloadSample(
-          file=parts[0],
-          sample_date=parts[1],
-          downloads_total=int(parts[3]),
-          sha256_total=int(parts[4]),
-          sig_total=int(parts[5]),
-          product=parts[6],
-          version=NoneToNull(parts[7]),
-          arch=NoneToNull(parts[8]),
-          os=NoneToNull(parts[9]),
-          extension=NoneToNull(parts[10]),
-          installer=parts[11] == 'installer',
-          downloads=0,
-          sha256=0,
-          sig=0)
+  def __init__(self, history, connection, window=1, backfill=True,
+               dry_run=True):
+    self.history = history
+    self.connection = connection
+    self.window = window
+    self.backfill = backfill
+    self.dry_run = dry_run
+    self.cursor = None
 
-      sample_day = datetime.datetime.strptime(sample.sample_date, "%Y-%m-%d")
-      day = (sample_day - epoch).days
+  def upload_file(self, file):
+    if not self.dry_run:
+      self.cursor = self.connection.cursor()
 
-      previous = history.get((sample.product, sample.file, sample.version, day-1))
-      downloads = sha256 = sig=0
-      if not previous:
-        print(sample.product, sample.file, sample.version, sample.sample_date,
-              '=No history')
-      else:
-         downloads = sample.downloads_total - previous.downloads_total
-         sha256 = sample.sha256_total - previous.sha256_total
-         sig = sample.sig_total - previous.sig_total
+    with open(file, 'r') as inp:
+      print('uploading:', file)
+      for line in inp:
+        # file| ymd | hm | count | #sha | #sig | product | version | arch | os
+        #     extension
+        parts = line.strip().split('|')
+        sample = DownloadSample(
+            file=parts[0],
+            sample_date=parts[1],
+            downloads_total=int(parts[3]),
+            sha256_total=int(parts[4]),
+            sig_total=int(parts[5]),
+            product=parts[6],
+            version=none_to_null(parts[7]),
+            arch=none_to_null(parts[8]),
+            os=none_to_null(parts[9]),
+            extension=none_to_null(parts[10]),
+            installer=parts[11] == 'installer',
+            downloads=0,
+            sha256=0,
+            sig=0)
+        self.process_sample(sample)
 
-         if (downloads > 10) and (previous.downloads * 115 // 100 < downloads):
-           print(sample.product, sample.file, sample.version, sample.sample_date,
-                 downloads, 'large jump from %d' % previous.downloads)
+    if not self.dry_run:
+      self.cursor.close()
+      self.connection.commit()
 
-      cmd = """INSERT INTO gh_downloads(
-          sample_date, filename, downloads_total, sha256_total, sig_total,
-          product, version, arch, os, extension, is_installer,
-          downloads, sha256, sig)
-      VALUES(
-          '%s', '%s', %d, %d, %d, '%s', '%s', '%s', '%s', '%s', %d,
-          %d, %d, %d
-      )""" % (sample.sample_date, sample.file,
-              sample.downloads_total, sample.sha256_total, sample.sig_total,
-              sample.product, sample.version, sample.arch, sample.os,
-              sample.extension, 1 if sample.installer else 0,
-              downloads, sha256, sig,
-              )
-      history[(sample.product, sample.file, sample.version, day)] = \
-          DownloadSample(
-              file=sample.file,
-              sample_date=sample.sample_date,
-              downloads_total=sample.downloads_total,
-              sha256_total=sample.sha256_total,
-              sig_total=sample.sig_total,
-              product=sample.product,
-              version=sample.version,
-              arch=sample.arch,
-              os=sample.os,
-              extension=sample.extension,
-              installer=sample.installer,
-              downloads=downloads,
-              sha256=sha256,
-              sig=sig)
+  def process_sample(self, sample):
+    sample_dt = datetime.datetime.strptime(sample.sample_date, '%Y-%m-%d')
+    sample_day = (sample_dt - _EPOCH).days
+    downloads = sha256 = sig= 0
 
-      if not dry_run:
-        cursor.execute(cmd)
-  if not dry_run:
-    cursor.close()
-    connection.commit()
+    if self.history.get(
+        (sample.product, sample.file, sample.version, sample_day)):
+      raise Exception('We have already loaded %s %s %s %s' % (
+          sample.product, sample.file, sample.version, sample_day))
+
+    previous = None
+    previous_day = sample_day
+    while not previous and sample_day - previous_day <= self.window:
+      previous_day -= 1
+      previous = self.history.get(
+          (sample.product, sample.file, sample.version, previous_day))
+
+    if not previous:
+      print(sample.product, sample.file, sample.version, sample.sample_date,
+            '=No history')
+    else:
+      downloads = sample.downloads_total - previous.downloads_total
+      sha256 = sample.sha256_total - previous.sha256_total
+      sig = sample.sig_total - previous.sig_total
+
+      fill_days = sample_day - previous_day
+      if self.backfill and fill_days > 1:
+        # backfill algorithm:
+        # - spread delta over all the days to be inserted. this includes
+        #   the sample for today
+        # - leave any rounding error in the sample for today.
+        inc_downloads = downloads // fill_days
+        inc_sha256 = sha256 // fill_days
+        inc_sig = sig // fill_days
+
+        for day_to_fill in range(previous_day + 1, sample_day):
+          filler = self.new_sample(sample, day_to_fill, inc_downloads,
+                                   inc_sha256, inc_sig)
+          print('backfill: %s %s %s %s' % (
+              filler.sample_date, filler.product, filler.version,
+              filler.downloads))
+          self.add_daily_counts(filler)
+          downloads -= inc_downloads
+          sha256 -= inc_sha256
+          sig -= inc_sig
+
+      # assert: no need to backfill: downloads is what we got today
+      # assert: with backfill: downloads holds ~avg/day change over period
+      # assert: skip backfill: downloads holds multi-day delta
+      if (downloads > 10) and (previous.downloads * 115 // 100 < downloads):
+        print(sample.product, sample.file, sample.version,
+              sample.sample_date, downloads,
+              'large jump from %d' % previous.downloads)
+
+    s = self.new_sample(sample, sample_day, downloads, sha256, sig)
+    self.add_daily_counts(s)
+
+
+  def add_daily_counts(self, sample):
+    cmd = """INSERT INTO gh_downloads(
+        sample_date, filename, downloads_total, sha256_total, sig_total,
+        product, version, arch, os, extension, is_installer,
+        downloads, sha256, sig)
+    VALUES(
+        '%s', '%s', %d, %d, %d, '%s', '%s', '%s', '%s', '%s', %d,
+        %d, %d, %d
+    )""" % (sample.sample_date, sample.file,
+            sample.downloads_total, sample.sha256_total, sample.sig_total,
+            sample.product, sample.version, sample.arch, sample.os,
+            sample.extension, 1 if sample.installer else 0,
+            sample.downloads, sample.sha256, sample.sig
+            )
+    if _VERBOSE:
+      print('insert: %s %s %s %d' % (
+          sample.sample_date, sample.product, sample.version, sample.downloads))
+    if not self.dry_run:
+      self.cursor.execute(cmd)
+
+
+  def new_sample(self, sample, sample_day, downloads, sha256, sig):
+    sample_date = (_EPOCH + datetime.timedelta(days=sample_day)
+                   ).strftime('%Y-%m-%d')
+    s = DownloadSample(
+        file=sample.file,
+        sample_date=sample_date,
+        downloads_total=sample.downloads_total,
+        sha256_total=sample.sha256_total,
+        sig_total=sample.sig_total,
+        product=sample.product,
+        version=sample.version,
+        arch=sample.arch,
+        os=sample.os,
+        extension=sample.extension,
+        installer=sample.installer,
+        downloads=downloads,
+        sha256=sha256,
+        sig=sig)
+    self.history[(s.product, s.file, s.version, sample_day)] = s
+    return s
 
 
 def main():
-  parser = argparse.ArgumentParser(description='Upload categorized download counts')
+  parser = argparse.ArgumentParser(
+      description='Upload categorized download counts')
 
   parser.add_argument(
         '--database', default='metrics',
@@ -185,15 +251,22 @@ def main():
         '--dry_run', '-n', action='store_true',
         help='Just print updates, do not commit them')
   parser.add_argument(
-        '--window', type=int, default=7,
+        '--backfill', type=bool, default=True,
+        help='backfill gaps in data')
+  parser.add_argument(
+        '--window', type=int, default=14,
         help='How many days to look back in time')
   parser.add_argument('files', nargs='*')
   options = parser.parse_args()
 
   connection = cloudsql.Connect(options.database)
-  history = GatherPreviousDownloads(connection, options.window)
+  history = gather_previous_downloads(connection, options.window)
+  uploader = DailyCountUploader(
+      history, connection, dry_run=options.dry_run, window=options.window,
+      backfill=options.backfill)
+
   for file in options.files:
-    upload_file(file, history, connection, options.dry_run)
+    uploader.upload_file(file)
   connection.close()
 
 

--- a/upload_test.py
+++ b/upload_test.py
@@ -6,7 +6,7 @@ import unittest
 
 import upload
 
-_VERBOSE = True
+_VERBOSE = False
 
 
 class UploadTest(unittest.TestCase):

--- a/upload_test.py
+++ b/upload_test.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Tests for upload.py."""
+
+import datetime
+import unittest
+
+import upload
+
+_VERBOSE = False
+
+
+def str_to_dt(s):
+  return datetime.datetime.strptime(s, '%Y-%m-%d')
+
+
+def dt_to_str(dt):
+  return dt.strftime('%Y-%m-%d')
+
+
+class UploadTest(unittest.TestCase):
+
+  def setUp(self):
+    history = {}
+    self.uploader = upload.DailyCountUploader(
+        history, None, dry_run=True, window=7, backfill=True)
+    self.samples_added = []
+
+    def add_called(sample):
+      # capture each sample we would insert to database
+      self.samples_added.append(sample)
+
+    self.uploader.add_daily_counts = add_called
+
+  def prep_history(self, fake_history):
+    for fake in fake_history:
+      sample_date = fake[0]
+      sample_dt = str_to_dt(sample_date)
+      sample_day = (sample_dt - upload._EPOCH).days
+      product = fake[1]
+      version = fake[2]
+      downloads = fake[3]
+      sha256 = fake[4]
+      sig = fake[5]
+      file = '%s-%s' % (product, version)
+      fake_download_sample = upload.DownloadSample(
+          sample_date=sample_date,
+          file=file,
+          product=product,
+          version=version,
+          downloads_total=downloads,
+          sha256_total=sha256,
+          sig_total=sig)
+      self.uploader.new_sample(
+          fake_download_sample, sample_day, downloads, sha256, sig)
+    if _VERBOSE:
+      for k, v in self.uploader.history.items():
+        print(k, v.downloads_total, v.sha256_total, v.sig_total)
+
+
+  def test_nobackfill(self):
+    product = 'foo'
+    version = '1'
+    self.prep_history([
+        ('2019-09-03', product, version, 50, 30, 10),
+    ])
+    last_dt = str_to_dt('2019-09-03')
+
+    file = '%s-%s' % (product, version)
+    sample_date = '2019-09-04'
+
+    delta_downloads = 70
+    delta_sha256 = 60
+    delta_sig = 20
+
+    s = upload.DownloadSample(
+        sample_date=sample_date,
+        file=file,
+        product=product,
+        version=version,
+        downloads_total=50 + delta_downloads,
+        sha256_total=30 + delta_sha256,
+        sig_total=10 + delta_sig)
+    self.uploader.process_sample(s)
+
+    self.assertEqual(1, len(self.samples_added))
+    self.assertEqual(delta_downloads, self.samples_added[0].downloads)
+    self.assertEqual(delta_sha256, self.samples_added[0].sha256)
+    self.assertEqual(delta_sig, self.samples_added[0].sig)
+
+
+  def test_backfill(self):
+    product = 'foo'
+    version = '1'
+    self.prep_history([
+        ('2019-09-03', product, version, 50, 30, 10),
+    ])
+    last_dt = str_to_dt('2019-09-03')
+
+    file = '%s-%s' % (product, version)
+    sample_date = '2019-09-08'  # backfill 4 days
+    n_backfill = 4
+
+    delta_downloads = 70
+    delta_sha256 = 60
+    delta_sig = 20
+
+    s = upload.DownloadSample(
+        sample_date=sample_date,
+        file=file,
+        product=product,
+        version=version,
+        downloads_total=50 + delta_downloads * (n_backfill + 1) + 1,
+        sha256_total=30 + delta_sha256 * (n_backfill  + 1)+ 2,
+        sig_total=10 + delta_sig * (n_backfill + 1) + 3)
+    self.uploader.process_sample(s)
+
+    if _VERBOSE:
+      for s in self.samples_added:
+        print(s)
+
+    self.assertEqual(n_backfill+1, len(self.samples_added))
+    for n in range(n_backfill):
+      self.assertEqual(
+          dt_to_str(last_dt + datetime.timedelta(days=n+1)),
+          self.samples_added[n].sample_date)
+      self.assertEqual(
+          (s.downloads_total - 50) // (n_backfill + 1),
+          self.samples_added[n].downloads)
+      self.assertEqual(
+          (s.sha256_total - 30) // (n_backfill + 1),
+          self.samples_added[n].sha256)
+      self.assertEqual(
+          (s.sig_total - 10) // (n_backfill + 1),
+          self.samples_added[n].sig)
+
+    # Not alignment with the sample created above
+    self.assertEqual(delta_downloads + 1,
+                     self.samples_added[n_backfill].downloads)
+    self.assertEqual(delta_sha256 + 2, self.samples_added[n_backfill].sha256)
+    self.assertEqual(delta_sig + 3, self.samples_added[n_backfill].sig)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
We were doing date diff calculations by using both the date and days since an arbitrary epoch (2019-1-1).  That was confusing. This change replaces that with better date computations so we simply diff the python date objects. 

I have been using this for a week or two now for the daily update.