### PR TITLE
Add a tool to generate the URL to show issues not assigned to a team

### DIFF
--- a/make_github_query.py
+++ b/make_github_query.py
@@ -1,35 +1,10 @@
 #!/usr/bin/env python3
 
 import argparse
-import collections
-import datetime
-import io
-import sys
 import urllib
 
-# from google.cloud import storage
-import categorize
 import github
 
-
-DEFAULT_REPOS_BIG = [
-    'bazelbuild/bazel',
-    'bazelbuild/bazel-gazelle',
-    'bazelbuild/bazelisk',
-    'bazelbuild/bazel-skylib',
-    'bazelbuild/bazel-website',
-    'bazelbuild/buildtools',
-    'bazelbuild/rules_android',
-    'bazelbuild/rules_apple',
-    'bazelbuild/rules_cc',
-    'bazelbuild/rules_docker',
-    'bazelbuild/rules_foreign_cc',
-    'bazelbuild/rules_kotlin',
-    'bazelbuild/rules_python',
-    'bazelbuild/rules_rust',
-    'bazelbuild/skydoc',
-    'bazelbuild/starlark',
-]
 
 DEFAULT_REPOS = [
     'bazelbuild/bazel',

--- a/make_github_query.py
+++ b/make_github_query.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import argparse
+import collections
+import datetime
+import io
+import sys
+import urllib
+
+# from google.cloud import storage
+import categorize
+import github
+
+
+DEFAULT_REPOS_BIG = [
+    'bazelbuild/bazel',
+    'bazelbuild/bazel-gazelle',
+    'bazelbuild/bazelisk',
+    'bazelbuild/bazel-skylib',
+    'bazelbuild/bazel-website',
+    'bazelbuild/buildtools',
+    'bazelbuild/rules_android',
+    'bazelbuild/rules_apple',
+    'bazelbuild/rules_cc',
+    'bazelbuild/rules_docker',
+    'bazelbuild/rules_foreign_cc',
+    'bazelbuild/rules_kotlin',
+    'bazelbuild/rules_python',
+    'bazelbuild/rules_rust',
+    'bazelbuild/skydoc',
+    'bazelbuild/starlark',
+]
+
+DEFAULT_REPOS = [
+    'bazelbuild/bazel',
+]
+
+def generate_untriaged_issue_url(repo, labels):
+  args = [
+    'utf8=%E2%9C%93'
+  ]
+  q = [
+    'is%3Aissue',
+    'is%3Aopen',
+    '-label%3Arelease'
+  ]
+  for label in labels:
+    name = label['name']
+    if name.lower().startswith('team-'):
+      q.append('-label%%3A%s' % name)
+  args.append('q=%s' % '+'.join(q))
+  url = 'https://github.com/%s/issues?%s' % (repo, '&'.join(args))
+  # https://github.com/bazelbuild/bazel/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3Ateam-starlark+-label%3Ateam-ExternalDeps+-label%3Ateam-Rules_java
+  return url
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Collect Bazel repo download metrics')
+
+  parser.add_argument(
+      '--all', action='store_true',
+      help='Get all repositories rather than just the select ones')
+  parser.add_argument(
+      '--repo_list_file', action='store',
+      help='Get repositories listed in this file')
+
+  args = parser.parse_args()
+  repos = DEFAULT_REPOS
+  if args.all:
+    repos = github.fetch_repos('bazelbuild')
+  if args.repo_list_file:
+    with open(args.repo_list_file, 'r') as rf:
+      repos = [l.strip() for l in rf.read().strip().split('\n')]
+
+  for repo in repos:
+    labels = github.fetch_labels(repo)
+    print(generate_untriaged_issue_url(repo, labels))
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+-label%3Arelease+-label%3Ateam-Android+-label%3Ateam-Apple+-label%3Ateam-Bazel+-label%3Ateam-Configurability+-label%3Ateam-Core+-label%3Ateam-EngProd+-label%3Ateam-ExternalDeps+-label%3Ateam-Front-End+-label%3Ateam-Local-Exec+-label%3Ateam-Performance+-label%3Ateam-Remote-Exec+-label%3Ateam-Rules-CPP+-label%3Ateam-Rules-Java+-label%3Ateam-Rules-Python+-label%3Ateam-Rules-Server+-label%3Ateam-Starlark+-label%3Ateam-Windows+-label%3Ateam-XProduct

No one should have to build this by hand. Running in the showy playlist bazel-standard right now. We can improve it over time.